### PR TITLE
support for new Amazon Echo 2

### DIFF
--- a/echo.coffee
+++ b/echo.coffee
@@ -250,7 +250,7 @@ module.exports = (env) =>
 
     _getDeviceResponse: (device) =>
       deviceType = @_getDeviceType(device)
-      env.logger.debug "DLU DEBUG: get device config for deviceType: #{deviceType}"
+      env.logger.debug "providing device config for deviceType: #{deviceType}"
       switch deviceType
         when "Dimmer"
           return {


### PR DESCRIPTION
Doku change required:

. /api is called by the echo 2 to receive a userId. A static ID is handed over
. the hueType needs to be set for switches (non dimmers). Else the echo would throw brightness events when switching lights on which will result in an error notified via voice by alexa
. Port 80 has to be used (maybe by some investigation, the description.xml could include a hint for echo to not use port 80)


Changes

. removed debug log for using ip address
. added multiple debug messages
. added a Hue DeviceType attribute for echo config to differ between dimmer and switch
. changed the expected ST attribute in the UDP discovery from 'urn:schemas-upnp-org:device:basic:1' to 'upnp:rootdevice'
. added support for retrieving API userId
. added support for SwitchBased Hue deviceType (‘On/Off plug-in unit’)

Fixes

. changed analysis of message for changing device states
. removed empty services the description.xml